### PR TITLE
fix: timestamp 기본 데이터 추가 (#25)

### DIFF
--- a/Server/RealTimeTradingSite/stocks/models.py
+++ b/Server/RealTimeTradingSite/stocks/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.utils import timezone
 
 class StockInfo(models.Model):
     id = models.BigAutoField(primary_key=True)
@@ -7,7 +8,7 @@ class StockInfo(models.Model):
     start_price = models.FloatField()
     current_price = models.FloatField()
     rate_of_change = models.FloatField()
-    timestamp = models.DateTimeField()
+    timestamp = models.DateTimeField(default=timezone.now)
     percentage_diff = models.FloatField(blank=True, null=True)
 
     class Meta:


### PR DESCRIPTION
### PR 타입
-[fix] :  timestamp 기본 데이터 추가

### 구현 사항
- timestamp가 DB 테이블에는 not null이여서 초기 데이터 생성 시 기본 값이 필요하여 기본 값을 현재 시간으로 지정하였음.