### PR TITLE
feat: queryClient 파일 분리 및 전역 에러 핸들링 구현 (#31)

### DIFF
--- a/Client/src/App.tsx
+++ b/Client/src/App.tsx
@@ -1,11 +1,10 @@
 import { RouterProvider } from 'react-router-dom';
 import router from './router';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-
-const queryClient = new QueryClient();
+import { queryClient } from './react-query/queryClient';
 
 function App() {
   return (

--- a/Client/src/react-query/queryClient.ts
+++ b/Client/src/react-query/queryClient.ts
@@ -1,0 +1,22 @@
+import { AxiosError } from 'axios';
+import { toast } from 'react-toastify';
+import { APIError } from '../types/api';
+import { MutationCache, QueryCache, QueryClient } from '@tanstack/react-query';
+
+export function queryErrorHandler(error: unknown): void {
+  const Message =
+    error instanceof AxiosError<APIError>
+      ? error?.response?.data.message
+      : 'error connecting to server';
+
+  toast.error(Message);
+}
+
+export const queryClient = new QueryClient({
+  queryCache: new QueryCache({
+    onError: queryErrorHandler,
+  }),
+  mutationCache: new MutationCache({
+    onError: queryErrorHandler,
+  }),
+});


### PR DESCRIPTION
### PR 타입
-[feat] : queryClient 파일 분리 및 전역 에러 핸들링 구현

### 구현 사항
- App.tsx의 queryClient를 별개의 파일로 분리하여 관리
- mutation, query 전역 에러 핸들링 구현