### PR TITLE
feat: stock data 전역 호출 처리 및 recoil적용 (#45)

### DIFF
--- a/Client/src/App.tsx
+++ b/Client/src/App.tsx
@@ -1,3 +1,4 @@
+import { RecoilRoot } from 'recoil'; // RecoilRoot 추가
 import { RouterProvider } from 'react-router-dom';
 import router from './router';
 import { QueryClientProvider } from '@tanstack/react-query';
@@ -11,11 +12,13 @@ function App() {
   return (
     <>
       <QueryClientProvider client={queryClient}>
-        <ToastContainer position="top-center" autoClose={1500} />
-        <S.Center>
-          <RouterProvider router={router} />
-        </S.Center>
-        <ReactQueryDevtools />
+        <RecoilRoot>
+          <ToastContainer position="top-center" autoClose={1500} />
+          <S.Center>
+            <RouterProvider router={router} />
+          </S.Center>
+          <ReactQueryDevtools />
+        </RecoilRoot>
       </QueryClientProvider>
     </>
   );

--- a/Client/src/components/Commons/Navbar.tsx
+++ b/Client/src/components/Commons/Navbar.tsx
@@ -2,10 +2,13 @@ import { useNavigate } from 'react-router-dom';
 import { Navbar, Container, Nav } from 'react-bootstrap';
 import { S } from './styled';
 import useLogout from '../../hooks/useLogout';
+import { useStockData } from '../../services/stockInfo';
 
 function NavBar() {
   const navigate = useNavigate();
   const { logout } = useLogout();
+
+  useStockData();
 
   return (
     <>

--- a/Client/src/hooks/useStockTableInstance.ts
+++ b/Client/src/hooks/useStockTableInstance.ts
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 import { Column, useTable } from 'react-table';
 import { StockInformation } from '../types/stock';
-import { useGetStockInfo } from '../services/stockInfo';
+import { useRecoilState } from 'recoil';
+import { stockDataState } from '../recoil/stockInfo/atoms';
 
 export const useStockTableInstance = () => {
-  const { data } = useGetStockInfo();
+  const stockData = useRecoilState(stockDataState);
 
   const columns = useMemo<Column<StockInformation>[]>(
     () => [
@@ -34,7 +35,7 @@ export const useStockTableInstance = () => {
 
   const tableInstance = useTable({
     columns,
-    data: data,
+    data: stockData[0],
   });
 
   return tableInstance;

--- a/Client/src/recoil/stockInfo/atoms.ts
+++ b/Client/src/recoil/stockInfo/atoms.ts
@@ -1,0 +1,7 @@
+import { atom } from 'recoil';
+import { StockInformation } from '../../types/stock';
+
+export const stockDataState = atom<StockInformation[]>({
+  key: 'stockData',
+  default: [],
+});

--- a/Client/src/services/stockInfo.ts
+++ b/Client/src/services/stockInfo.ts
@@ -2,11 +2,25 @@ import { useQuery } from '@tanstack/react-query';
 import { StockInformation } from '../types/stock';
 import { getStockInfo } from '../apis/stockinfo';
 import { QUERY_KEYS } from '../utils/constants';
+import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+import { stockDataState } from '../recoil/stockInfo/atoms';
 
-export const useGetStockInfo = () => {
-  return useQuery<StockInformation[]>([QUERY_KEYS.STOCK_INFO], getStockInfo, {
-    refetchOnWindowFocus: false,
-    initialData: [],
-    refetchInterval: 2000,
-  });
+export const useStockData = () => {
+  const [recoilStockData, setRecoilStockData] = useRecoilState(stockDataState);
+
+  const { data: stockData } = useQuery<StockInformation[]>(
+    [QUERY_KEYS.STOCK_INFO],
+    getStockInfo,
+    {
+      initialData: recoilStockData,
+      refetchInterval: 1000,
+    }
+  );
+
+  useEffect(() => {
+    setRecoilStockData(stockData);
+  }, [stockData, setRecoilStockData]);
+
+  return { stockData: recoilStockData };
 };


### PR DESCRIPTION
### PR 타입
-[feat] : stock data 전역 호출 처리 및 recoil적용 (#45)

### 구현 사항
- stock data가 모든 페이지에서 동등하게 호출되게끔 하기위해 공통 컴포넌트인 NavBar 컴포넌트에서 호출하게 변경
- react-query를 통해 1초마다 반복 호출되는 서버데이터는 recoil으로 상태관리
- StockInfo에 있는 usequery를 제거하고 useRecoilState로 데이터를 출력