### PR TITLE
feat: 주식 세부 정보 캐싱 및 캐싱데이터 지속 조회 커스텀 훅 구현 (#48)

### DIFF
--- a/Client/src/apis/stockinfo.ts
+++ b/Client/src/apis/stockinfo.ts
@@ -11,3 +11,15 @@ export const getStockInfo = async (): Promise<StockInformation[]> => {
     return [];
   }
 };
+
+export const getStockDetailInfo = async (
+  stockId: string
+): Promise<StockInformation> => {
+  try {
+    const response = await instance.get(`${ApiUrl.stockinfo}/${stockId}`);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};

--- a/Client/src/components/StockInfo/StockDetailInfo.tsx
+++ b/Client/src/components/StockInfo/StockDetailInfo.tsx
@@ -1,23 +1,24 @@
 import { useParams } from 'react-router-dom';
 import { StockDetailParams } from '../../types/stock';
-import { useRecoilValue } from 'recoil';
-import { selectedStockDataState } from '../../recoil/stockInfo/selectors';
+
+import { QUERY_KEYS } from '../../utils/constants';
+import useContinuousStockDetail from '../../hooks/useContinuousStockDetail';
+import { getStockDetailInfo } from '../../apis/stockinfo';
 
 function StockDetailInfo(): JSX.Element {
   const { stockNumber, stockDetailId } = useParams<StockDetailParams>();
-  const selectedStockData = useRecoilValue(
-    selectedStockDataState(stockNumber || '')
+  const queryKey = `${QUERY_KEYS.STOCK_INFO}_${stockDetailId}`;
+  const data = useContinuousStockDetail(
+    queryKey,
+    () => getStockDetailInfo(stockDetailId as string),
+    2000
   );
-
-  console.log(selectedStockData);
-  // to do list
-  // 1. 빈배열일때는 스피너
-  // 2. 배열이 채워지면 데이터를 활용한 UI 출력
 
   return (
     <>
       <h2>Stock Detail Page</h2>
       <p>Displaying content for ID: {stockDetailId}</p>
+      <p>{data?.current_price}</p>
     </>
   );
 }

--- a/Client/src/hooks/useContinuousStockDetail.ts
+++ b/Client/src/hooks/useContinuousStockDetail.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { StockInformation } from '../types/stock';
+
+type FetchDataFunction = () => Promise<StockInformation>;
+
+function useContinuousStockDetail(
+  queryKey: string,
+  fetchDataFunction: FetchDataFunction,
+  IntervalTime: number
+) {
+  const { data } = useQuery<StockInformation>([queryKey], fetchDataFunction, {
+    refetchInterval: IntervalTime,
+  });
+
+  return data;
+}
+
+export default useContinuousStockDetail;

--- a/Client/src/services/stockInfo.ts
+++ b/Client/src/services/stockInfo.ts
@@ -1,12 +1,13 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { StockInformation } from '../types/stock';
-import { getStockInfo } from '../apis/stockinfo';
+import { getStockInfo, getStockDetailInfo } from '../apis/stockinfo';
 import { QUERY_KEYS } from '../utils/constants';
 import { useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 import { stockDataState } from '../recoil/stockInfo/atoms';
 
 export const useStockData = () => {
+  const queryClient = useQueryClient();
   const [recoilStockData, setRecoilStockData] = useRecoilState(stockDataState);
 
   const { data: stockData } = useQuery<StockInformation[]>(
@@ -14,13 +15,22 @@ export const useStockData = () => {
     getStockInfo,
     {
       initialData: recoilStockData,
-      refetchInterval: 1000,
+      refetchInterval: 1500,
     }
   );
 
   useEffect(() => {
     setRecoilStockData(stockData);
-  }, [stockData, setRecoilStockData]);
+    const queryKeys = stockData.map((stock) => {
+      return `${stock.id}`;
+    });
+
+    queryKeys.forEach((queryKey) => {
+      queryClient.prefetchQuery([`${QUERY_KEYS.STOCK_INFO}_${queryKey}`], () =>
+        getStockDetailInfo(queryKey)
+      );
+    });
+  }, [stockData]);
 
   return { stockData: recoilStockData };
 };


### PR DESCRIPTION
### PR 타입
-[feat] : 주식 세부 정보 캐싱 및 캐싱데이터 지속 조회 커스텀 훅 구현

### 구현 사항
- prefetchQuery을 사용한 주식 세부 정보 10개 캐싱
- useContinuousStockDetail -> 캐싱된 주식 세부 정보를 지속적으로 가져오는 커스텀 훅 
- 캐싱데이터를 활용하여 주식 세부 정보 페이지 구현중