### PR TITLE
fix: 주식 상세 정보 조회 Api Url 수정 및 3000번 포트 CORS 허용 (#49)

### DIFF
--- a/Server/RealTimeTradingSite/RealTimeTradingSite/settings.py
+++ b/Server/RealTimeTradingSite/RealTimeTradingSite/settings.py
@@ -76,6 +76,7 @@ AUTHENTICATION_BACKENDS = [
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -83,8 +84,9 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'corsheaders.middleware.CorsMiddleware',
 ]
+
+CORS_ALLOWED_ORIGINS = ['http://localhost:3000', 'http://127.0.0.1:3000']
 
 ROOT_URLCONF = 'RealTimeTradingSite.urls'
 

--- a/Server/RealTimeTradingSite/stocks/urls.py
+++ b/Server/RealTimeTradingSite/stocks/urls.py
@@ -8,7 +8,7 @@ router = routers.DefaultRouter()
 urlpatterns = [
     path('', include(router.urls)),
     path('stockinfo', StockInfoList.as_view(), name='stock_info_list'),
-    path('stocks/<int:pk>/', StockInfoDetail.as_view(), name='stock-detail'),
+    path('stockinfo/<int:pk>/', StockInfoDetail.as_view(), name='stock-detail'),
     path('purchase_stock', UserStocksCreate.as_view(), name='user-stocks-create'),
     path('sell_stock', SellStocksAPIView.as_view(), name='user-stocks-create'),
     path('signin', UserSigninAPIView.as_view(), name='user-signin'),


### PR DESCRIPTION
### PR 타입
-[fix] : 주식 상세 정보 조회 Api Url 수정 및 3000번 포트 CORS 허용

### 구현 사항
- 주식 상세 정보 조회 Api Url 변경 (stocks/id -> stockinfo/id)
- 3000번 포트 (front) CORS 허용