### PR TITLE
fix: 시가(start_price) 데이터 삽입 로직 수정 (#50)

### DIFF
--- a/Server/RealTimeTradingSite/stocks/views.py
+++ b/Server/RealTimeTradingSite/stocks/views.py
@@ -100,9 +100,8 @@ class StockInfoList(APIView):
             except StockInfo.DoesNotExist:
                 if StockInfo.objects.filter(name=name, timestamp__date=yesterday_date).exists():
                     yesterday_stock = StockInfo.objects.get(name=name, timestamp__date=yesterday_date)
-                    volatility = random.uniform(-0.005, 0.005)
-                    start_price = round(yesterday_stock.current_price * (1 + volatility), 2)
-                    stock = StockInfo.objects.create(name=name, start_price=start_price, yesterday_price=yesterday_stock.current_price,
+                    start_price = yesterday_stock.current_price
+                    stock = StockInfo.objects.create(name=name, start_price=start_price, yesterday_price=start_price,
                                                      current_price=start_price, rate_of_change=0, percentage_diff=0)
                     if yesterday_date != current_date:
                         stock.percentage_diff = round((stock.start_price - stock.yesterday_price) / stock.start_price * 100, 2)
@@ -128,6 +127,7 @@ class StockInfoList(APIView):
             }
             stocks.append(stock_data)
         return Response(stocks)
+
 
 class StockInfoDetail(APIView):
     def get(self, request, pk):


### PR DESCRIPTION
### PR 타입
-[fix] : 시가(start_price) 데이터 삽입 로직 수정

### 구현 사항
- 어제 종가(yesterday_price)에서 랜덤 연산을 거치지않고 바로 삽입하게끔 수정