### PR TITLE
fix: stockDetail 캐싱 로직 변경 및 적용, selectorFamily 로직 변경 (#51)

### DIFF
--- a/Client/src/components/StockInfo/StockDetailInfo.tsx
+++ b/Client/src/components/StockInfo/StockDetailInfo.tsx
@@ -1,24 +1,20 @@
 import { useParams } from 'react-router-dom';
 import { StockDetailParams } from '../../types/stock';
-
-import { QUERY_KEYS } from '../../utils/constants';
-import useContinuousStockDetail from '../../hooks/useContinuousStockDetail';
-import { getStockDetailInfo } from '../../apis/stockinfo';
+import { useRecoilValue } from 'recoil';
+import { selectedStockDataState } from '../../recoil/stockInfo/selectors';
 
 function StockDetailInfo(): JSX.Element {
   const { stockNumber, stockDetailId } = useParams<StockDetailParams>();
-  const queryKey = `${QUERY_KEYS.STOCK_INFO}_${stockDetailId}`;
-  const data = useContinuousStockDetail(
-    queryKey,
-    () => getStockDetailInfo(stockDetailId as string),
-    2000
+
+  const recoilData = useRecoilValue(
+    selectedStockDataState(stockNumber as string)
   );
 
   return (
     <>
       <h2>Stock Detail Page</h2>
       <p>Displaying content for ID: {stockDetailId}</p>
-      <p>{data?.current_price}</p>
+      <p>{recoilData?.current_price}</p>
     </>
   );
 }

--- a/Client/src/recoil/stockInfo/selectors.ts
+++ b/Client/src/recoil/stockInfo/selectors.ts
@@ -8,10 +8,10 @@ export const selectedStockDataState = selectorFamily({
     ({ get }) => {
       const stockData = get(stockDataState);
       const stockIndex = Number(index);
-      if (stockIndex >= 0 && stockIndex < stockData.length) {
-        return stockData[stockIndex];
+      if (stockIndex >= 0 && stockIndex <= stockData.length) {
+        return stockData[stockIndex - 1];
       }
 
-      return [];
+      return null;
     },
 });

--- a/Client/src/services/stockInfo.ts
+++ b/Client/src/services/stockInfo.ts
@@ -1,13 +1,12 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { StockInformation } from '../types/stock';
-import { getStockInfo, getStockDetailInfo } from '../apis/stockinfo';
+import { getStockInfo } from '../apis/stockinfo';
 import { QUERY_KEYS } from '../utils/constants';
 import { useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 import { stockDataState } from '../recoil/stockInfo/atoms';
 
 export const useStockData = () => {
-  const queryClient = useQueryClient();
   const [recoilStockData, setRecoilStockData] = useRecoilState(stockDataState);
 
   const { data: stockData } = useQuery<StockInformation[]>(
@@ -15,22 +14,13 @@ export const useStockData = () => {
     getStockInfo,
     {
       initialData: recoilStockData,
-      refetchInterval: 1500,
+      refetchInterval: 2000,
     }
   );
 
   useEffect(() => {
     setRecoilStockData(stockData);
-    const queryKeys = stockData.map((stock) => {
-      return `${stock.id}`;
-    });
-
-    queryKeys.forEach((queryKey) => {
-      queryClient.prefetchQuery([`${QUERY_KEYS.STOCK_INFO}_${queryKey}`], () =>
-        getStockDetailInfo(queryKey)
-      );
-    });
-  }, [stockData]);
+  }, [stockData, setRecoilStockData]);
 
   return { stockData: recoilStockData };
 };


### PR DESCRIPTION
### PR 타입
-[fix] : stockDetail 캐싱 로직 변경 및 적용, selectorFamily 로직 변경

### 구현 사항
- prefetch로 상세 정보 api 불러와 캐싱하는 방법이 아닌 전체 정보에서 selectorFamily를 통해 캐싱
- seletorFamily 로직 변경