### PR TITLE
feat: echart 적용 및 가격 1일 히스토리 atom 생성 및 적용 (#60)

### DIFF
--- a/Client/src/components/Chart/StockPriceHistoryChart.tsx
+++ b/Client/src/components/Chart/StockPriceHistoryChart.tsx
@@ -1,0 +1,36 @@
+import ECharts from 'echarts-for-react';
+
+interface ChartProps {
+  priceData: number[];
+}
+
+export function StockPriceHistoryChart({ priceData }: ChartProps) {
+  const options = {
+    xAxis: {
+      type: 'category',
+      show: false,
+    },
+    yAxis: {
+      type: 'value',
+    },
+    tooltip: {
+      trigger: 'axis',
+      formatter: '{c}원',
+    },
+    series: [
+      {
+        data: priceData,
+        type: 'line',
+      },
+    ],
+  };
+
+  return (
+    <>
+      <ECharts
+        option={options}
+        opts={{ renderer: 'svg', width: 500, height: 500 }}
+      />
+    </>
+  );
+}

--- a/Client/src/components/StockInfo/StockDetailInfo.tsx
+++ b/Client/src/components/StockInfo/StockDetailInfo.tsx
@@ -1,20 +1,32 @@
 import { useParams } from 'react-router-dom';
 import { StockDetailParams } from '../../types/stock';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useRecoilState } from 'recoil';
 import { selectedStockDataState } from '../../recoil/stockInfo/selectors';
+import { useStockPriceHistory } from '../../services/stockInfo';
+import { stockPriceHistoryState } from '../../recoil/stockInfo/atoms';
+import { StockPriceHistoryChart } from '../Chart/StockPriceHistoryChart';
 
 function StockDetailInfo(): JSX.Element {
   const { stockNumber, stockDetailId } = useParams<StockDetailParams>();
-
+  const stockPriceHistory = useRecoilState(stockPriceHistoryState);
   const recoilData = useRecoilValue(
     selectedStockDataState(stockNumber as string)
   );
+  const currentPrices: number[] = stockPriceHistory[0].map(
+    (item) => item.current_price
+  );
+  const timeStamps: string[] = stockPriceHistory[0].map(
+    (item) => item.timestamp
+  );
+
+  useStockPriceHistory(Number(stockNumber), '1');
 
   return (
     <>
       <h2>Stock Detail Page</h2>
       <p>Displaying content for ID: {stockDetailId}</p>
       <p>{recoilData?.current_price}</p>
+      <StockPriceHistoryChart priceData={currentPrices} />
     </>
   );
 }

--- a/Client/src/recoil/stockInfo/atoms.ts
+++ b/Client/src/recoil/stockInfo/atoms.ts
@@ -1,7 +1,12 @@
 import { atom } from 'recoil';
-import { StockInformation } from '../../types/stock';
+import { StockInformation, StockPriceHistory } from '../../types/stock';
 
 export const stockDataState = atom<StockInformation[]>({
   key: 'stockData',
+  default: [],
+});
+
+export const stockPriceHistoryState = atom<StockPriceHistory[]>({
+  key: 'stockPriceHis',
   default: [],
 });


### PR DESCRIPTION
### PR 타입
-[feat] :  echart 적용 및 가격 1일 히스토리 atom 생성 및 적용

### 구현 사항
- echart 적용 (진행 중)
- 주식 가격 1일 히스토리 데이터 관리를 위한 stockPriceHistoryState 생성