### PR TITLE
fix: 주식 정보 조회 시 랜덤으로 부여되는 값 수정 (#70)

### DIFF
--- a/Server/RealTimeTradingSite/stocks/views.py
+++ b/Server/RealTimeTradingSite/stocks/views.py
@@ -165,7 +165,7 @@ class StockInfoList(APIView):
             name = f"Stock {i+1}"
             try:
                 stock = StockInfo.objects.get(name=name, timestamp__date=current_date)
-                volatility = random.uniform(-0.005, 0.005)
+                volatility = random.uniform(-0.001, 0.001)
                 stock.current_price = round(stock.current_price * (1 + volatility), 2)
                 stock.rate_of_change = round((stock.current_price - stock.start_price) / stock.start_price * 100, 2)
                 stock.save()


### PR DESCRIPTION
### PR 타입
-[fix] : 주식 정보 조회 시 랜덤으로 부여되는 값 수정

### 구현 사항
- 주식 정보 조회 시 랜덤으로 부여되는 값 수정 (0.5% -> 0.1%)

### 수정 이유
- 장시간 랜덤한 값을 부여하니 주식의 가격이 시가보다 +- 20%가 부여되버리는 경우가 있어서 랜덤 값을 수정