### PR TITLE
fix: useSetRecoilState 컴포넌트 밖으로 이동 (#90)

### DIFF
--- a/Client/src/components/StockInfo/RateOfChange.tsx
+++ b/Client/src/components/StockInfo/RateOfChange.tsx
@@ -4,6 +4,7 @@ import {
   stockDataState,
 } from '../../recoil/stockInfo/atoms';
 import { StockPrice, DownArrowIcon, UpArrowIcon } from './styled';
+import { useEffect } from 'react';
 
 type KeysProps = {
   keys: string;
@@ -25,7 +26,6 @@ export function RateOfChange(keys: KeysProps) {
       const startPrice = selectedStock.start_price;
       const rateOfChange = selectedStock.rate_of_change;
 
-      setCurrentPriceState(currentPrice);
       return {
         currentPrice,
         isLower: currentPrice < startPrice,
@@ -39,8 +39,12 @@ export function RateOfChange(keys: KeysProps) {
       rateOfChange: 0,
     };
   };
-
   const stockPriceData = getStockPrice(keys.keys);
+
+  useEffect(() => {
+    setCurrentPriceState(stockPriceData.currentPrice);
+  }, [keys, setCurrentPriceState]);
+
   return (
     <StockPrice isLower={stockPriceData.isLower}>
       ${stockPriceData.currentPrice} / {stockPriceData.rateOfChange}%


### PR DESCRIPTION
### PR 타입
-[fix] : useSetRecoilState 컴포넌트 밖으로 이동

### 구현 사항
- hook이 컴포넌트 안에서 실행되어 발생하는 에러 해결