### PR TITLE
fix: 최근 본 주식 리스트 첫 조회시 null object 에러 해결 (#93)

### DIFF
--- a/Client/src/components/Commons/Button.tsx
+++ b/Client/src/components/Commons/Button.tsx
@@ -1,0 +1,5 @@
+function Button() {
+  return <button>hi</button>;
+}
+
+export default Button;

--- a/Client/src/components/StockInfo/RecentStockList.tsx
+++ b/Client/src/components/StockInfo/RecentStockList.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { RecentStockListItem } from '../../types/stock';
 import storage from '../../utils/localStorage';
 import { RateOfChange } from './RateOfChange';
 import {
@@ -12,12 +13,15 @@ import {
 } from './styled';
 
 export function RecentStockList() {
-  const [recentStockItem, setRecentStockItem] = useState(
-    JSON.parse(storage.get('views') as string)
+  const [recentStockItem, setRecentStockItem] = useState<RecentStockListItem>(
+    () => {
+      const storedViews = storage.get('views') as string;
+      return storedViews ? JSON.parse(storedViews) : {};
+    }
   );
+
   const keys = Object.keys(recentStockItem);
   const navigate = useNavigate();
-
   const handleKeyClick = (key: string) => {
     navigate(recentStockItem[key]);
   };

--- a/Client/src/types/stock.ts
+++ b/Client/src/types/stock.ts
@@ -24,3 +24,7 @@ export interface StockPriceHistory {
 export type StockPriceProps = {
   isLower: boolean;
 };
+
+export interface RecentStockListItem {
+  [key: string]: string;
+}


### PR DESCRIPTION
### PR 타입
-[fix] : 최근 본 주식 리스트 첫 조회시 null object 에러 해결

### 구현 사항
- 최근 본 주식 리스트를 storage에서 조회 시 없다면 빈 객체를 생성하게끔 구현하여 에러 수정