### PR TITLE
feat: 주식 상세 정보 페이지의 세부 기능 탭 UI 구현

### DIFF
--- a/Client/src/components/Comment/Comment.tsx
+++ b/Client/src/components/Comment/Comment.tsx
@@ -1,10 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
 import { memo, ReactElement, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { commentIdState, modalState } from '../../recoil/board/atoms';
-import { useCommentList, useEditComment } from '../../services/board';
+import { useEditComment } from '../../services/board';
 import { CommentData } from '../../types/board';
 import { StockDetailParams } from '../../types/stock';
+import { QUERY_KEYS } from '../../utils/constants';
 import storage from '../../utils/localStorage';
 import Popup from './Popup';
 import {
@@ -31,7 +33,11 @@ function Comment(): ReactElement {
     null
   );
   const [commentText, setCommentText] = useState<string>('');
-  const getCommentList = useCommentList(stockName as string);
+  const { data: getCommentList } = useQuery<CommentData[]>([
+    `${QUERY_KEYS.GET_COMMENT_LIST}/${stockName}`,
+  ]);
+
+  console.log(getCommentList);
   const [, setModal] = useRecoilState(modalState);
   const [, setCommentId] = useRecoilState(commentIdState);
   const editCommentMutation = useEditComment(stockName || '');

--- a/Client/src/components/StockInfo/StockDetailTab.tsx
+++ b/Client/src/components/StockInfo/StockDetailTab.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { StockDetailParams } from '../../types/stock';
+import CommentInput from '../Comment/CommentInput';
+import Comment from '../Comment/Comment';
+import StockTradingListTable from './StockTradingListTable';
+import {
+  CommentContainer,
+  ListTableContainer,
+  TabButton,
+  TabContainer,
+} from './styled';
+
+export function StockDetailTab() {
+  const [activeTab, setActiveTab] = useState<number>(0);
+  const { stockName } = useParams<StockDetailParams>();
+
+  const handleTabClick = (tabNumber: number) => {
+    setActiveTab(tabNumber);
+  };
+
+  return (
+    <TabContainer>
+      <TabButton onClick={() => handleTabClick(1)} isActive={activeTab === 1}>
+        커뮤니티
+      </TabButton>
+      <TabButton onClick={() => handleTabClick(2)} isActive={activeTab === 2}>
+        호가
+      </TabButton>
+      {activeTab === 1 && (
+        <CommentContainer>
+          <CommentInput stockName={stockName as string} />
+          <Comment />
+        </CommentContainer>
+      )}
+      {activeTab === 2 && (
+        <ListTableContainer>
+          <StockTradingListTable />
+        </ListTableContainer>
+      )}
+    </TabContainer>
+  );
+}

--- a/Client/src/components/StockInfo/styled.ts
+++ b/Client/src/components/StockInfo/styled.ts
@@ -3,7 +3,7 @@ import { StyledCommonflexCenter } from '../../style/common.styled';
 import { ReactComponent as DeleteBtnImg } from '../../assets/icons/btn-close-gray.svg';
 import { ReactComponent as UpArrowIconImg } from '../../assets/icons/icon_up.svg';
 import { ReactComponent as DownArrowIconImg } from '../../assets/icons/icon_down.svg';
-import { StockPriceProps } from '../../types/stock';
+import { StockDetailTabButtonProps, StockPriceProps } from '../../types/stock';
 
 export const StockTableContainer = styled.div`
   width: 100%;
@@ -98,4 +98,39 @@ export const UpArrowIcon = styled(UpArrowIconImg)`
   height: 10px;
   margin-left: 3px;
   padding-bottom: 3px;
+`;
+
+export const CommentContainer = styled.div`
+  flex-flow: column wrap;
+  ${StyledCommonflexCenter}
+  width: 100%;
+`;
+
+export const ListTableContainer = styled.div`
+  flex-flow: column wrap;
+  ${StyledCommonflexCenter}
+  width: 100%;
+`;
+
+export const TabContainer = styled.div`
+  flex-flow: row wrap;
+  ${StyledCommonflexCenter}
+  width: 100%;
+`;
+
+export const TabButton = styled.button<StockDetailTabButtonProps>`
+  height: 50px;
+  background-color: transparent;
+  border: transparent;
+  font-family: var(--font-nanumfont);
+  font-size: 16px;
+  font-weight: 700;
+  color: ${(props) => (props.isActive ? 'black' : 'gray')};
+  border-bottom: ${(props) => (props.isActive ? '2px solid gray' : 'none')};
+
+  &:hover,
+  &:active {
+    color: black;
+    border-bottom: 2px solid gray;
+  }
 `;

--- a/Client/src/pages/StockDetailInfo.tsx
+++ b/Client/src/pages/StockDetailInfo.tsx
@@ -7,8 +7,7 @@ import { StockPriceHistoryChart } from '../components/Chart/StockPriceHistoryCha
 import { Suspense } from 'react';
 import LoadingSpinner from '../components/Commons/Spinner';
 import { RateOfChange } from '../components/StockInfo/RateOfChange';
-import Comment from '../components/Comment/Comment';
-import CommentInput from '../components/Comment/CommentInput';
+import { useCommentList } from '../services/board';
 
 function StockDetailInfo(): JSX.Element {
   const { stockName } = useParams<StockDetailParams>();
@@ -16,7 +15,8 @@ function StockDetailInfo(): JSX.Element {
     selectedStockDataState(stockName as string)
   );
   useStockPriceHistory(stockName as string, '30');
-  useStockData(); // 해당 함수가 계속 데이터가 바뀌면서 자식 컴포넌트 리렌더링을 유발하므로 차후에 수정 필요
+  useStockData();
+  useCommentList(stockName as string);
 
   if (!recoilData) {
     return <p>Error: Stock data is undefined.</p>;
@@ -28,9 +28,6 @@ function StockDetailInfo(): JSX.Element {
         <p>현재 가격</p>
         <RateOfChange keys={recoilData.name} />
         <StockPriceHistoryChart />
-
-        <CommentInput stockName={stockName as string} />
-        <Comment />
       </Suspense>
     </>
   );

--- a/Client/src/pages/StockDetailInfo.tsx
+++ b/Client/src/pages/StockDetailInfo.tsx
@@ -7,6 +7,7 @@ import { StockPriceHistoryChart } from '../components/Chart/StockPriceHistoryCha
 import { Suspense } from 'react';
 import LoadingSpinner from '../components/Commons/Spinner';
 import { RateOfChange } from '../components/StockInfo/RateOfChange';
+import { StockDetailTab } from '../components/StockInfo/StockDetailTab';
 import { useCommentList } from '../services/board';
 
 function StockDetailInfo(): JSX.Element {
@@ -28,6 +29,7 @@ function StockDetailInfo(): JSX.Element {
         <p>현재 가격</p>
         <RateOfChange keys={recoilData.name} />
         <StockPriceHistoryChart />
+        <StockDetailTab />
       </Suspense>
     </>
   );

--- a/Client/src/types/stock.ts
+++ b/Client/src/types/stock.ts
@@ -28,3 +28,7 @@ export type StockPriceProps = {
 export interface RecentStockListItem {
   [key: string]: string;
 }
+
+export interface StockDetailTabButtonProps {
+  isActive: boolean;
+}


### PR DESCRIPTION
### PR 타입
-[feat] : 주식 상세 정보 페이지의 세부 기능 탭 UI 구현

### 구현 사항
- 주식 상세 정보 페이지의 세부 기능 탭 UI 구현 및 스타일 코드 구현
- 주식 상세 정보 페이지의 세부 기능 탭 기능 구현에 따른 댓글 데이터 호출 위치 수정
- 탭 버튼에 대한 Props 타입 추가