### PR TITLE
refactor: useSuspenseQueries를 활용할 query data 병렬 처리

### DIFF
--- a/Client/package-lock.json
+++ b/Client/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@nivo/line": "^0.83.0",
+        "@suspensive/react": "^1.20.8",
+        "@suspensive/react-query": "^1.20.8",
         "@tanstack/react-query": "^4.35.3",
         "@tanstack/react-query-devtools": "^4.35.3",
         "@testing-library/jest-dom": "^5.16.5",
@@ -3447,6 +3449,37 @@
         "json5": "^2.2.0",
         "magic-string": "^0.25.0",
         "string.prototype.matchall": "^4.0.6"
+      }
+    },
+    "node_modules/@suspensive/react": {
+      "version": "1.20.8",
+      "resolved": "https://registry.npmjs.org/@suspensive/react/-/react-1.20.8.tgz",
+      "integrity": "sha512-He5aNgqy2Kk3i8kiVOx7Utc3/W+qzoY4h5T9n2Km4z5O6qtEHRtSnuu1dsC4+DonIRWBnj8sHmwkftYYK83kTg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/manudeli"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18"
+      }
+    },
+    "node_modules/@suspensive/react-query": {
+      "version": "1.20.8",
+      "resolved": "https://registry.npmjs.org/@suspensive/react-query/-/react-query-1.20.8.tgz",
+      "integrity": "sha512-AWL6Dab+pDYg7mbKRt/A52jOU876XmkoPMphDBB7z78iS8gEyAJXynHdAhf2VbUQgdMF2Y/5vXhnQ6Sy8179FA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/manudeli"
+      },
+      "peerDependencies": {
+        "@suspensive/react": "^1.20.8",
+        "@tanstack/react-query": "^4",
+        "react": "^16.8 || ^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "@suspensive/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {

--- a/Client/package.json
+++ b/Client/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "dependencies": {
     "@nivo/line": "^0.83.0",
+    "@suspensive/react": "^1.20.8",
+    "@suspensive/react-query": "^1.20.8",
     "@tanstack/react-query": "^4.35.3",
     "@tanstack/react-query-devtools": "^4.35.3",
     "@testing-library/jest-dom": "^5.16.5",

--- a/Client/src/pages/StockDetailInfo.tsx
+++ b/Client/src/pages/StockDetailInfo.tsx
@@ -2,24 +2,22 @@ import { useParams } from 'react-router-dom';
 import { StockDetailParams } from '../types/stock';
 import { useRecoilValue } from 'recoil';
 import { selectedStockDataState } from '../recoil/stockInfo/selectors';
-import { useStockData, useStockPriceHistory } from '../services/stockInfo';
+import { useGetStockDetailInfos } from '../services/stockInfo';
 import { StockPriceHistoryChart } from '../components/Chart/StockPriceHistoryChart';
 import { Suspense } from 'react';
 import LoadingSpinner from '../components/Commons/Spinner';
 import { RateOfChange } from '../components/StockInfo/RateOfChange';
 import { StockDetailTab } from '../components/StockInfo/StockDetailTab';
-import { useCommentList } from '../services/board';
 
 function StockDetailInfo(): JSX.Element {
   const { stockName } = useParams<StockDetailParams>();
-  const recoilData = useRecoilValue(
+  const selectedStockData = useRecoilValue(
     selectedStockDataState(stockName as string)
   );
-  useStockPriceHistory(stockName as string, '30');
-  useStockData();
-  useCommentList(stockName as string);
 
-  if (!recoilData) {
+  useGetStockDetailInfos(stockName as string, '30');
+
+  if (!selectedStockData) {
     return <p>Error: Stock data is undefined.</p>;
   }
 
@@ -27,7 +25,7 @@ function StockDetailInfo(): JSX.Element {
     <>
       <Suspense fallback={<LoadingSpinner />}>
         <p>현재 가격</p>
-        <RateOfChange keys={recoilData.name} />
+        <RateOfChange keys={selectedStockData.name} />
         <StockPriceHistoryChart />
         <StockDetailTab />
       </Suspense>


### PR DESCRIPTION
### PR 타입
-[refactor] : useSuspenseQueries를 활용할 query data 병렬 처리

### 구현 사항
- useSuspenseQueries를 활용할 query data 병렬 처리 (주식 정보, 댓글 정보, 주식 가격 히스토리)
- @suspensive/react-query 라이브러리 설치